### PR TITLE
Mark all string parameters as comptime where the C API is expecting string literals.

### DIFF
--- a/src/ztracy.zig
+++ b/src/ztracy.zig
@@ -41,7 +41,7 @@ const tracy_stub = struct {
         }
     };
 
-    pub inline fn SetThreadName(name: [*:0]const u8) void {
+    pub inline fn SetThreadName(comptime name: [*:0]const u8) void {
         _ = name;
     }
 
@@ -49,7 +49,7 @@ const tracy_stub = struct {
         _ = src;
         return .{};
     }
-    pub inline fn ZoneN(comptime src: Src, name: [*:0]const u8) ZoneCtx {
+    pub inline fn ZoneN(comptime src: Src, comptime name: [*:0]const u8) ZoneCtx {
         _ = src;
         _ = name;
         return .{};
@@ -59,7 +59,7 @@ const tracy_stub = struct {
         _ = color;
         return .{};
     }
-    pub inline fn ZoneNC(comptime src: Src, name: [*:0]const u8, color: u32) ZoneCtx {
+    pub inline fn ZoneNC(comptime src: Src, comptime name: [*:0]const u8, color: u32) ZoneCtx {
         _ = src;
         _ = name;
         _ = color;
@@ -70,7 +70,7 @@ const tracy_stub = struct {
         _ = depth;
         return .{};
     }
-    pub inline fn ZoneNS(comptime src: Src, name: [*:0]const u8, depth: i32) ZoneCtx {
+    pub inline fn ZoneNS(comptime src: Src, comptime name: [*:0]const u8, depth: i32) ZoneCtx {
         _ = src;
         _ = name;
         _ = depth;
@@ -82,7 +82,7 @@ const tracy_stub = struct {
         _ = depth;
         return .{};
     }
-    pub inline fn ZoneNCS(comptime src: Src, name: [*:0]const u8, color: u32, depth: i32) ZoneCtx {
+    pub inline fn ZoneNCS(comptime src: Src, comptime name: [*:0]const u8, color: u32, depth: i32) ZoneCtx {
         _ = src;
         _ = name;
         _ = color;
@@ -123,42 +123,42 @@ const tracy_stub = struct {
         _ = depth;
     }
 
-    pub inline fn AllocN(ptr: ?*const anyopaque, size: usize, name: [*:0]const u8) void {
+    pub inline fn AllocN(ptr: ?*const anyopaque, size: usize, comptime name: [*:0]const u8) void {
         _ = ptr;
         _ = size;
         _ = name;
     }
-    pub inline fn FreeN(ptr: ?*const anyopaque, name: [*:0]const u8) void {
+    pub inline fn FreeN(ptr: ?*const anyopaque, comptime name: [*:0]const u8) void {
         _ = ptr;
         _ = name;
     }
-    pub inline fn SecureAllocN(ptr: ?*const anyopaque, size: usize, name: [*:0]const u8) void {
-        _ = ptr;
-        _ = size;
-        _ = name;
-    }
-    pub inline fn SecureFreeN(ptr: ?*const anyopaque, name: [*:0]const u8) void {
-        _ = ptr;
-        _ = name;
-    }
-    pub inline fn AllocNS(ptr: ?*const anyopaque, size: usize, depth: c_int, name: [*:0]const u8) void {
+    pub inline fn SecureAllocN(ptr: ?*const anyopaque, size: usize, comptime name: [*:0]const u8) void {
         _ = ptr;
         _ = size;
-        _ = depth;
         _ = name;
     }
-    pub inline fn FreeNS(ptr: ?*const anyopaque, depth: c_int, name: [*:0]const u8) void {
+    pub inline fn SecureFreeN(ptr: ?*const anyopaque, comptime name: [*:0]const u8) void {
         _ = ptr;
-        _ = depth;
         _ = name;
     }
-    pub inline fn SecureAllocNS(ptr: ?*const anyopaque, size: usize, depth: c_int, name: [*:0]const u8) void {
+    pub inline fn AllocNS(ptr: ?*const anyopaque, size: usize, depth: c_int, comptime name: [*:0]const u8) void {
         _ = ptr;
         _ = size;
         _ = depth;
         _ = name;
     }
-    pub inline fn SecureFreeNS(ptr: ?*const anyopaque, depth: c_int, name: [*:0]const u8) void {
+    pub inline fn FreeNS(ptr: ?*const anyopaque, depth: c_int, comptime name: [*:0]const u8) void {
+        _ = ptr;
+        _ = depth;
+        _ = name;
+    }
+    pub inline fn SecureAllocNS(ptr: ?*const anyopaque, size: usize, depth: c_int, comptime name: [*:0]const u8) void {
+        _ = ptr;
+        _ = size;
+        _ = depth;
+        _ = name;
+    }
+    pub inline fn SecureFreeNS(ptr: ?*const anyopaque, depth: c_int, comptime name: [*:0]const u8) void {
         _ = ptr;
         _ = depth;
         _ = name;
@@ -167,14 +167,14 @@ const tracy_stub = struct {
     pub inline fn Message(text: []const u8) void {
         _ = text;
     }
-    pub inline fn MessageL(text: [*:0]const u8) void {
+    pub inline fn MessageL(comptime text: [*:0]const u8) void {
         _ = text;
     }
     pub inline fn MessageC(text: []const u8, color: u32) void {
         _ = text;
         _ = color;
     }
-    pub inline fn MessageLC(text: [*:0]const u8, color: u32) void {
+    pub inline fn MessageLC(comptime text: [*:0]const u8, color: u32) void {
         _ = text;
         _ = color;
     }
@@ -182,7 +182,7 @@ const tracy_stub = struct {
         _ = text;
         _ = depth;
     }
-    pub inline fn MessageLS(text: [*:0]const u8, depth: c_int) void {
+    pub inline fn MessageLS(comptime text: [*:0]const u8, depth: c_int) void {
         _ = text;
         _ = depth;
     }
@@ -191,20 +191,20 @@ const tracy_stub = struct {
         _ = color;
         _ = depth;
     }
-    pub inline fn MessageLCS(text: [*:0]const u8, color: u32, depth: c_int) void {
+    pub inline fn MessageLCS(comptime text: [*:0]const u8, color: u32, depth: c_int) void {
         _ = text;
         _ = color;
         _ = depth;
     }
 
     pub inline fn FrameMark() void {}
-    pub inline fn FrameMarkNamed(name: [*:0]const u8) void {
+    pub inline fn FrameMarkNamed(comptime name: [*:0]const u8) void {
         _ = name;
     }
-    pub inline fn FrameMarkStart(name: [*:0]const u8) void {
+    pub inline fn FrameMarkStart(comptime name: [*:0]const u8) void {
         _ = name;
     }
-    pub inline fn FrameMarkEnd(name: [*:0]const u8) void {
+    pub inline fn FrameMarkEnd(comptime name: [*:0]const u8) void {
         _ = name;
     }
     pub inline fn FrameImage(image: ?*const anyopaque, width: u16, height: u16, offset: u8, flip: c_int) void {
@@ -215,20 +215,20 @@ const tracy_stub = struct {
         _ = flip;
     }
 
-    pub inline fn FiberEnter(name: [*:0]const u8) void {
+    pub inline fn FiberEnter(comptime name: [*:0]const u8) void {
         _ = name;
     }
     pub inline fn FiberLeave() void {}
 
-    pub inline fn PlotF(name: [*:0]const u8, val: f64) void {
+    pub inline fn PlotF(comptime name: [*:0]const u8, val: f64) void {
         _ = name;
         _ = val;
     }
-    pub inline fn PlotU(name: [*:0]const u8, val: u64) void {
+    pub inline fn PlotU(comptime name: [*:0]const u8, val: u64) void {
         _ = name;
         _ = val;
     }
-    pub inline fn PlotI(name: [*:0]const u8, val: i64) void {
+    pub inline fn PlotI(comptime name: [*:0]const u8, val: i64) void {
         _ = name;
         _ = val;
     }
@@ -309,27 +309,19 @@ const tracy_full = struct {
         }
     };
 
-    inline fn initZone(comptime src: Src, name: ?[*:0]const u8, color: u32, depth: c_int) ZoneCtx {
+    inline fn initZone(comptime src: Src, comptime name: ?[*:0]const u8, comptime color: u32, comptime depth: c_int) ZoneCtx {
         // Tracy uses pointer identity to identify contexts.
         // The `src` parameter being comptime ensures that
         // each zone gets its own unique global location for this
         // struct.
         const static = struct {
-            var loc: c.___tracy_source_location_data = undefined;
-
-            // Ensure that a unique struct type is generated for each unique `src`. See
-            // https://github.com/ziglang/zig/issues/18816
-            comptime {
-                // https://github.com/ziglang/zig/issues/19274
-                _ = @sizeOf(@TypeOf(src));
-            }
-        };
-        static.loc = .{
-            .name = name,
-            .function = src.fn_name.ptr,
-            .file = src.file.ptr,
-            .line = src.line,
-            .color = color,
+            const loc: c.___tracy_source_location_data = .{
+                .name = name,
+                .function = src.fn_name.ptr,
+                .file = src.file.ptr,
+                .line = src.line,
+                .color = color,
+            };
         };
 
         const zone = if (has_callstack_support)
@@ -345,32 +337,32 @@ const tracy_full = struct {
         }
     }
 
-    pub inline fn SetThreadName(name: [*:0]const u8) void {
+    pub inline fn SetThreadName(comptime name: [*:0]const u8) void {
         c.___tracy_set_thread_name(name);
     }
 
     pub inline fn Zone(comptime src: Src) ZoneCtx {
         return initZone(src, null, 0, callstack_depth);
     }
-    pub inline fn ZoneN(comptime src: Src, name: [*:0]const u8) ZoneCtx {
+    pub inline fn ZoneN(comptime src: Src, comptime name: [*:0]const u8) ZoneCtx {
         return initZone(src, name, 0, callstack_depth);
     }
     pub inline fn ZoneC(comptime src: Src, color: u32) ZoneCtx {
         return initZone(src, null, color, callstack_depth);
     }
-    pub inline fn ZoneNC(comptime src: Src, name: [*:0]const u8, color: u32) ZoneCtx {
+    pub inline fn ZoneNC(comptime src: Src, comptime name: [*:0]const u8, color: u32) ZoneCtx {
         return initZone(src, name, color, callstack_depth);
     }
     pub inline fn ZoneS(comptime src: Src, depth: i32) ZoneCtx {
         return initZone(src, null, 0, depth);
     }
-    pub inline fn ZoneNS(comptime src: Src, name: [*:0]const u8, depth: i32) ZoneCtx {
+    pub inline fn ZoneNS(comptime src: Src, comptime name: [*:0]const u8, depth: i32) ZoneCtx {
         return initZone(src, name, 0, depth);
     }
     pub inline fn ZoneCS(comptime src: Src, color: u32, depth: i32) ZoneCtx {
         return initZone(src, null, color, depth);
     }
-    pub inline fn ZoneNCS(comptime src: Src, name: [*:0]const u8, color: u32, depth: i32) ZoneCtx {
+    pub inline fn ZoneNCS(comptime src: Src, comptime name: [*:0]const u8, color: u32, depth: i32) ZoneCtx {
         return initZone(src, name, color, depth);
     }
 
@@ -431,56 +423,56 @@ const tracy_full = struct {
         }
     }
 
-    pub inline fn AllocN(ptr: ?*const anyopaque, size: usize, name: [*:0]const u8) void {
+    pub inline fn AllocN(ptr: ?*const anyopaque, size: usize, comptime name: [*:0]const u8) void {
         if (has_callstack_support) {
             c.___tracy_emit_memory_alloc_callstack_named(ptr, size, callstack_depth, 0, name);
         } else {
             c.___tracy_emit_memory_alloc_named(ptr, size, 0, name);
         }
     }
-    pub inline fn FreeN(ptr: ?*const anyopaque, name: [*:0]const u8) void {
+    pub inline fn FreeN(ptr: ?*const anyopaque, comptime name: [*:0]const u8) void {
         if (has_callstack_support) {
             c.___tracy_emit_memory_free_callstack_named(ptr, callstack_depth, 0, name);
         } else {
             c.___tracy_emit_memory_free_named(ptr, 0, name);
         }
     }
-    pub inline fn SecureAllocN(ptr: ?*const anyopaque, size: usize, name: [*:0]const u8) void {
+    pub inline fn SecureAllocN(ptr: ?*const anyopaque, size: usize, comptime name: [*:0]const u8) void {
         if (has_callstack_support) {
             c.___tracy_emit_memory_alloc_callstack_named(ptr, size, callstack_depth, 1, name);
         } else {
             c.___tracy_emit_memory_alloc_named(ptr, size, 1, name);
         }
     }
-    pub inline fn SecureFreeN(ptr: ?*const anyopaque, name: [*:0]const u8) void {
+    pub inline fn SecureFreeN(ptr: ?*const anyopaque, comptime name: [*:0]const u8) void {
         if (has_callstack_support) {
             c.___tracy_emit_memory_free_callstack_named(ptr, callstack_depth, 1, name);
         } else {
             c.___tracy_emit_memory_free_named(ptr, 1, name);
         }
     }
-    pub inline fn AllocNS(ptr: ?*const anyopaque, size: usize, depth: c_int, name: [*:0]const u8) void {
+    pub inline fn AllocNS(ptr: ?*const anyopaque, size: usize, depth: c_int, comptime name: [*:0]const u8) void {
         if (has_callstack_support) {
             c.___tracy_emit_memory_alloc_callstack_named(ptr, size, depth, 0, name);
         } else {
             c.___tracy_emit_memory_alloc_named(ptr, size, 0, name);
         }
     }
-    pub inline fn FreeNS(ptr: ?*const anyopaque, depth: c_int, name: [*:0]const u8) void {
+    pub inline fn FreeNS(ptr: ?*const anyopaque, depth: c_int, comptime name: [*:0]const u8) void {
         if (has_callstack_support) {
             c.___tracy_emit_memory_free_callstack_named(ptr, depth, 0, name);
         } else {
             c.___tracy_emit_memory_free_named(ptr, 0, name);
         }
     }
-    pub inline fn SecureAllocNS(ptr: ?*const anyopaque, size: usize, depth: c_int, name: [*:0]const u8) void {
+    pub inline fn SecureAllocNS(ptr: ?*const anyopaque, size: usize, depth: c_int, comptime name: [*:0]const u8) void {
         if (has_callstack_support) {
             c.___tracy_emit_memory_alloc_callstack_named(ptr, size, depth, 1, name);
         } else {
             c.___tracy_emit_memory_alloc_named(ptr, size, 1, name);
         }
     }
-    pub inline fn SecureFreeNS(ptr: ?*const anyopaque, depth: c_int, name: [*:0]const u8) void {
+    pub inline fn SecureFreeNS(ptr: ?*const anyopaque, depth: c_int, comptime name: [*:0]const u8) void {
         if (has_callstack_support) {
             c.___tracy_emit_memory_free_callstack_named(ptr, depth, 1, name);
         } else {
@@ -491,20 +483,20 @@ const tracy_full = struct {
     pub inline fn Message(text: []const u8) void {
         c.___tracy_emit_message(text.ptr, text.len, callstack_depth);
     }
-    pub inline fn MessageL(text: [*:0]const u8, color: u32) void {
+    pub inline fn MessageL(comptime text: [*:0]const u8, color: u32) void {
         c.___tracy_emit_messageL(text, color, callstack_depth);
     }
     pub inline fn MessageC(text: []const u8, color: u32) void {
         c.___tracy_emit_messageC(text.ptr, text.len, color, callstack_depth);
     }
-    pub inline fn MessageLC(text: [*:0]const u8, color: u32) void {
+    pub inline fn MessageLC(comptime text: [*:0]const u8, color: u32) void {
         c.___tracy_emit_messageLC(text, color, callstack_depth);
     }
     pub inline fn MessageS(text: []const u8, depth: c_int) void {
         const inner_depth: c_int = if (has_callstack_support) depth else 0;
         c.___tracy_emit_message(text.ptr, text.len, inner_depth);
     }
-    pub inline fn MessageLS(text: [*:0]const u8, depth: c_int) void {
+    pub inline fn MessageLS(comptime text: [*:0]const u8, depth: c_int) void {
         const inner_depth: c_int = if (has_callstack_support) depth else 0;
         c.___tracy_emit_messageL(text, inner_depth);
     }
@@ -512,7 +504,7 @@ const tracy_full = struct {
         const inner_depth: c_int = if (has_callstack_support) depth else 0;
         c.___tracy_emit_messageC(text.ptr, text.len, color, inner_depth);
     }
-    pub inline fn MessageLCS(text: [*:0]const u8, color: u32, depth: c_int) void {
+    pub inline fn MessageLCS(comptime text: [*:0]const u8, color: u32, depth: c_int) void {
         const inner_depth: c_int = if (has_callstack_support) depth else 0;
         c.___tracy_emit_messageLC(text, color, inner_depth);
     }
@@ -520,33 +512,33 @@ const tracy_full = struct {
     pub inline fn FrameMark() void {
         c.___tracy_emit_frame_mark(null);
     }
-    pub inline fn FrameMarkNamed(name: [*:0]const u8) void {
+    pub inline fn FrameMarkNamed(comptime name: [*:0]const u8) void {
         c.___tracy_emit_frame_mark(name);
     }
-    pub inline fn FrameMarkStart(name: [*:0]const u8) void {
+    pub inline fn FrameMarkStart(comptime name: [*:0]const u8) void {
         c.___tracy_emit_frame_mark_start(name);
     }
-    pub inline fn FrameMarkEnd(name: [*:0]const u8) void {
+    pub inline fn FrameMarkEnd(comptime name: [*:0]const u8) void {
         c.___tracy_emit_frame_mark_end(name);
     }
     pub inline fn FrameImage(image: ?*const anyopaque, width: u16, height: u16, offset: u8, flip: c_int) void {
         c.___tracy_emit_frame_image(image, width, height, offset, flip);
     }
 
-    pub inline fn FiberEnter(name: [*:0]const u8) void {
+    pub inline fn FiberEnter(comptime name: [*:0]const u8) void {
         c.___tracy_fiber_enter(name);
     }
     pub inline fn FiberLeave() void {
         c.___tracy_fiber_leave();
     }
 
-    pub inline fn PlotF(name: [*:0]const u8, val: f64) void {
+    pub inline fn PlotF(comptime name: [*:0]const u8, val: f64) void {
         c.___tracy_emit_plot(name, val);
     }
-    pub inline fn PlotU(name: [*:0]const u8, val: u64) void {
+    pub inline fn PlotU(comptime name: [*:0]const u8, val: u64) void {
         c.___tracy_emit_plot(name, @as(f64, @floatFromInt(val)));
     }
-    pub inline fn PlotI(name: [*:0]const u8, val: i64) void {
+    pub inline fn PlotI(comptime name: [*:0]const u8, val: i64) void {
         c.___tracy_emit_plot(name, @as(f64, @floatFromInt(val)));
     }
     pub inline fn AppInfo(text: []const u8) void {


### PR DESCRIPTION
Pros:

* Prevents mistaken usage of dynamically allocated strings.
* Lets us use static constant memory for the source location data.
* Avoids generating unnecessary writes to source location data whenever starting a zone.
* Matches other Zig Tracy bindings such as the one inside the Zig compiler.

Cons:

* Breaking API change.
* Technically you are allowed to pass non-string literals to these functions, and you might want to if you are dynamically loading code/data containing your strings, or promise to keep your strings allocated until program exit. We could export the raw C API to cover more niche use-cases such as these though.