### PR TITLE
Updates for 0.17.x

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -33,8 +33,11 @@ pub fn build(b: *std.Build) void {
     };
 
     const options_step = b.addOptions();
-    inline for (std.meta.fields(@TypeOf(options))) |field| {
-        options_step.addOption(field.type, field.name, @field(options, field.name));
+    inline for (
+        comptime std.meta.fieldTypes(@TypeOf(options)),
+        comptime std.meta.fieldNames(@TypeOf(options)),
+    ) |field_type, field_name| {
+        options_step.addOption(field_type, field_name, @field(options, field_name));
     }
 
     const options_module = options_step.createModule();
@@ -109,19 +112,4 @@ pub fn build(b: *std.Build) void {
     }
 
     b.installArtifact(tracy);
-
-    const test_step = b.step("test", "Run ztracy tests");
-
-    const tests = b.addTest(.{
-        .name = "ztracy-tests",
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("src/ztracy.zig"),
-            .target = target,
-            .optimize = optimize,
-        }),
-    });
-    tests.root_module.linkLibrary(tracy);
-    b.installArtifact(tests);
-
-    test_step.dependOn(&b.addRunArtifact(tests).step);
 }

--- a/src/ztracy.zig
+++ b/src/ztracy.zig
@@ -78,7 +78,3 @@ pub const PlotI = if (enabled) impl.PlotI else stub.PlotI;
 pub const AppInfo = if (enabled) impl.AppInfo else stub.AppInfo;
 
 pub const TracyAllocator = if (enabled) impl.TracyAllocator else stub.TracyAllocator;
-
-test {
-    std.testing.refAllDeclsRecursive(@This());
-}


### PR DESCRIPTION
- Fixup deprecated std.meta.fields usage
- Remove deprecated refAllDeclsRecursive call. We should eventually add proper tests to replace this.